### PR TITLE
feat: add github workflow to generate downloads for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build .zip File
+
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch: # Run manually
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set environment variables
+        id: repo-name
+        shell: bash
+        run: |
+          echo "value=`basename ${{ github.repository }}`" >> $GITHUB_OUTPUT
+
+      - name: Zip Data Pack
+        run: zip -r ${{ github.workspace }}/${{ steps.repo-name.outputs.value }}-${{ github.ref_name }}.zip .
+        working-directory: ${{ github.workspace }}
+
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v2
+        # if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ${{ steps.repo-name.outputs.value }}-*.zip
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Automatically generates a github release when you create a tag (or manually trigger).

To use:

1. `git tag v1.21.10`
2. `git push --all`
3. There's no step 3!  (Workflow runs automatically and will generate `ModelApplier-v1.21.10.zip`)

To get this to run automatically, you will always have to generate (and push) a tag.